### PR TITLE
Remove unused `semistandard` dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "reify": "0.20.12",
     "rewire": "3.0.2",
     "run-sequence": "1.2.2",
-    "semistandard": "^16.0.1",
     "send": "0.18.0",
     "serve-static": "1.13.2",
     "server-destroy": "1.0.1",


### PR DESCRIPTION
`semistandard` was erroneously added as a dev dependency in #66 – it was added but never used

I encountered this when the backwards compatibility canary tests of `neostandard` suggested to include this repository and this repository was failing: https://github.com/neostandard/neostandard/pull/172